### PR TITLE
Add: Centralize types

### DIFF
--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,11 +1,8 @@
 import { Request, Response } from 'express';
 import * as bcrypt from 'bcrypt';
 import * as jwt from 'jsonwebtoken'; // JWT for authentication
-import User, { IUserDocument } from '../models/User'; // Your User model
-
-interface AuthenticatedRequest extends Request { // <--- This now correctly extends the imported Request
-    user?: IUserDocument;
-}
+import User from '../models/User';
+import { AuthenticatedRequest, IUserDocument } from '../types/declarations';
 
 // Helper function to generate a JWT
 const generateToken = (id: string) => {

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,9 +1,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 
-interface AppError extends Error {
-    statusCode?: number;
-}
+import { AppError } from '../types/declarations';
 
 const errorHandler = (err: AppError, req: Request, res: Response, next: NextFunction) => {
     const statusCode = err.statusCode || 500;

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -5,10 +5,7 @@ import { IUser } from '../../../shared/user.interface'; ;
 
 // Define IUserDocument as a HydratedDocument of IUser
 // This correctly gives it all properties of IUser AND Mongoose Document methods/properties. HydratedDocument is a utility type. It takes the IUser and returns a new type including Mongoose's Types with the one of IUser so the ID from Mongoose is used instead of the string ID from the interface.
-export interface IUserDocument extends HydratedDocument<IUser> {
-    passwordHash: string; 
-    matchPassword(enteredPassword: string): Promise<boolean>; 
-}
+import { IUserDocument } from '../types/declarations';
 const UserSchema: Schema<IUserDocument> = new Schema({
     username: {
         type: String,

--- a/backend/src/types/declarations.ts
+++ b/backend/src/types/declarations.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction } from 'express';
+import { HydratedDocument } from 'mongoose';
+import { IUser } from '../../../shared/user.interface';
+
+export interface AuthenticatedRequest extends Request {
+    user?: IUserDocument;
+}
+
+export interface AppError extends Error {
+    statusCode?: number;
+}
+
+export interface IUserDocument extends HydratedDocument<IUser> {
+    passwordHash: string; 
+    matchPassword(enteredPassword: string): Promise<boolean>; 
+}
+
+export type AsyncRequestHandler<T = Request> = (
+  req: T,
+  res: Response,
+  next: NextFunction
+) => Promise<any>;

--- a/backend/src/utils/asyncHandler.ts
+++ b/backend/src/utils/asyncHandler.ts
@@ -2,11 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 
 // This is a generic type for an Express request handler that can be used
 // with a custom request type.
-type AsyncRequestHandler<T = Request> = (
-  req: T,
-  res: Response,
-  next: NextFunction
-) => Promise<any>;
+import { AsyncRequestHandler } from '../types/declarations';
 
 const asyncHandler = <T = Request>(fn: AsyncRequestHandler<T>) =>
     (req: T, res: Response, next: NextFunction) => {


### PR DESCRIPTION
# Refactor: Centralize Type Definitions

  - Add:
     - src/types/declarations.ts: New file to centralize shared type definitions like AuthenticatedRequest, IUserDocument, AppError, and
       AsyncRequestHandler.

  - Change:
     - src/controllers/userController.ts, src/middleware/errorHandler.ts, src/models/User.ts, and src/utils/asyncHandler.ts were updated to
       import the necessary types from the new declarations.ts file.

  - Remove:
     - Removed the local definitions of the interfaces and types from the controller, middleware, model, and utility files, reducing code
       duplication.