### PR TITLE
Add: country, cities, languages etc as new options

### DIFF
--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -2,6 +2,11 @@ import mongoose, { HydratedDocument, Schema } from 'mongoose';
 import * as bcrypt from 'bcrypt';
 import { IUser } from '../../../shared/user.interface';
 import { IUserDocument } from '../types/declarations';
+import { getNames as getCountryNames } from 'country-list';
+import iso6391 from 'iso-639-1';
+
+const supportedCountries = getCountryNames();
+const supportedLanguages = iso6391.getAllNames();
 
 /**
  * Mongoose schema for the User model.
@@ -60,10 +65,50 @@ const UserSchema = new Schema<IUserDocument>({
         type: Boolean,
         default: true,
     },
+    profileOptions: {
+        nativeLanguage: {
+            type: String,
+            required: [true, 'Native language is required'],
+            enum: supportedLanguages, // Only allows values from the language list
+        },
+        practicingLanguage: {
+            language: {
+                type: String,
+                required: [true, 'Practicing language is required'],
+                enum: supportedLanguages, // Only allows values from the language list
+            },
+            proficiency: {
+                type: String,
+                enum: ['Beginner', 'Intermediate', 'Advanced'], // A predefined list for proficiency
+                required: [true, 'Proficiency level is required'],
+            }
+        },
+        country: {
+            type: String,
+            required: [true, 'Country is required'],
+            enum: supportedCountries, // Only allows values from the country list
+        },
+        city: {
+            type: String,
+            required: [true, 'City is required'],
+            trim: true,
+        },
+        gender: {
+            type: String,
+            required: [true, 'Gender is required'],
+            enum: ['Male', 'Female', 'Non-binary', 'Prefer not to say'],
+        },
+        age: {
+            type: Number,
+            required: [true, 'Age is required'],
+            min: [13, 'Age must be at least 13'], // Example minimum age
+            max: [120, 'Age cannot exceed 120'],
+        }
+    },
 }, {
     timestamps: true,
     toJSON: {
-        transform: function (doc: IUserDocument, ret: mongoose.FlatRecord<IUserDocument>): IUser {
+        transform: function ( ret: mongoose.FlatRecord<IUserDocument>): IUser {
             // 1. Destructure and omit sensitive fields
             const { passwordHash, _id, ...userObject } = ret;
 

--- a/backend/src/types/declarations.ts
+++ b/backend/src/types/declarations.ts
@@ -6,6 +6,12 @@ export interface AuthenticatedRequest extends Request {
     user?: IUserDocument;
 }
 
+export type AsyncRequestHandler<T = Request> = (
+  req: T,
+  res: Response,
+  next: NextFunction
+) => Promise<any>;
+
 export interface ErrorType extends Error {
     statusCode?: number;
 }
@@ -15,8 +21,24 @@ export interface IUserDocument extends HydratedDocument<IUser> {
     matchPassword(enteredPassword: string): Promise<boolean>; 
 }
 
-export type AsyncRequestHandler<T = Request> = (
-  req: T,
-  res: Response,
-  next: NextFunction
-) => Promise<any>;
+// src/types/requests.ts
+
+export interface IUserRegistrationRequest {
+    username: string;
+    email: string;
+    password: string;
+    firstName: string;
+    familyName: string;
+    bio: string;
+    profileOptions: {
+        nativeLanguage: string;
+        practicingLanguage: {
+            language: string;
+            proficiency: 'Beginner' | 'Intermediate' | 'Advanced';
+        };
+        country: string;
+        city: string;
+        gender: 'Male' | 'Female' | 'Non-binary' | 'Prefer not to say';
+        age: number;
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,38 @@
+{
+  "name": "LanguageExchangeApp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "country-list": "^2.3.0",
+        "iso-639-1": "^3.1.5"
+      },
+      "devDependencies": {
+        "@types/country-list": "^2.1.4"
+      }
+    },
+    "node_modules/@types/country-list": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/country-list/-/country-list-2.1.4.tgz",
+      "integrity": "sha512-c4orjm0wT+BRt6Ynf2/QRRL+iMX4SdLT11jAjKqkJ7mQr/DLOmdz7qR8i04j9Y7wFSoP70cXJc18FN4YGNgGaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/country-list": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/country-list/-/country-list-2.3.0.tgz",
+      "integrity": "sha512-qZk66RlmQm7fQjMYWku1AyjlKPogjPEorAZJG88owPExoPV8EsyCcuFLvO2afTXHEhi9liVOoyd+5A6ZS5QwaA==",
+      "license": "MIT"
+    },
+    "node_modules/iso-639-1": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-3.1.5.tgz",
+      "integrity": "sha512-gXkz5+KN7HrG0Q5UGqSMO2qB9AsbEeyLP54kF1YrMsIxmu+g4BdB7rflReZTSTZGpfj8wywu6pfPBCylPIzGQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "country-list": "^2.3.0",
+    "iso-639-1": "^3.1.5"
+  },
+  "devDependencies": {
+    "@types/country-list": "^2.1.4"
+  }
+}

--- a/shared/user.interface.ts
+++ b/shared/user.interface.ts
@@ -12,6 +12,18 @@ export interface IUser {
     lastLoginDate?: Date;
     createdAt: Date;
     updatedAt: Date;
+
+    profileOptions: {
+    nativeLanguage: string;
+    practicingLanguage: {
+        language: string;
+        proficiency: 'Beginner' | 'Intermediate' | 'Advanced';
+    };
+    country: string;
+    city: string;
+    gender: 'Male' | 'Female' | 'Non-binary' | 'Prefer not to say';
+    age: number;
+    };
 }
 
 export interface IUserRegisterRequest {


### PR DESCRIPTION
### Add user profile fields to registration

-Add: New user profile fields to the Mongoose schema.
-Add: Type definitions for `country-list` and the `iso-639-1` library.
-Add:  `IUserRegistrationRequest` interfaces for improved type safety.
-Change: Registration controller to accept and validate the new profile options from the request body.
-Change: IUser` interfaces for improved type safety.
