### PR TITLE
fix: default language on page load

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -2,7 +2,10 @@ import createMiddleware from "next-intl/middleware";
 
 import { routing } from "./src/i18n/routing";
 
-export default createMiddleware(routing);
+export default createMiddleware({
+  ...routing,
+  localePrefix: "as-needed",
+});
 
 export const config = {
   // Match all pathnames except for

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -9,14 +9,19 @@ export const metadata: Metadata = {
 
 type Props = {
   children: React.ReactNode;
-  params: Promise<{ locale: string }>;
+  params?: Promise<{ locale?: string }>;
 };
 
 /**
  * The root layout for the application.
  */
 export default async function RootLayout({ children, params }: Props) {
-  const { locale } = await params;
+  let locale = "en"; // default locale
+
+  if (params) {
+    const resolvedParams = await params;
+    locale = resolvedParams.locale || "en";
+  }
 
   return (
     <html lang={locale}>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default function RootPage() {
+  // Redirect to the default locale
+  redirect("/en");
+}


### PR DESCRIPTION
# Goal
Fix the on page load error.
Before this PR, when the page first load and url was http://localhost:3000/, it would throw an error and page not found would display, because of the wrong config of i18n.
This pr introduces a default to english when the page first loads, so we always have a page to display.
Ig the user wants to change language, there is a button for it.

## Evidence

https://github.com/user-attachments/assets/3e1b6401-4abe-419f-aacc-c24dd7761bb0

